### PR TITLE
Boot command section was NOT working

### DIFF
--- a/website/source/docs/builders/vmware-iso.html.markdown
+++ b/website/source/docs/builders/vmware-iso.html.markdown
@@ -311,7 +311,7 @@ The available variables are:
 Example boot command. This is actually a working boot command used to start
 an Ubuntu 12.04 installer:
 
-```javascript
+```
 [
   "<esc><esc><enter><wait>",
   "/install/vmlinuz noapic ",


### PR DESCRIPTION
If copy and pasted, the boot command section was NOT working due to < and > being translated to HTML code equivalents. Removed javascript tagging on the code block to see if this fixes the resulting display in a browser.