### PR TITLE
Boot command section was NOT working

### DIFF
--- a/website/source/docs/builders/virtualbox-iso.html.markdown
+++ b/website/source/docs/builders/virtualbox-iso.html.markdown
@@ -283,9 +283,9 @@ The available variables are:
 Example boot command. This is actually a working boot command used to start
 an Ubuntu 12.04 installer:
 
-```javascript
+```
 [
-  "&lt;esc&gt;&lt;esc&gt;&lt;enter&gt;&lt;wait&gt;",
+  "<esc><esc><enter><wait>",
   "/install/vmlinuz noapic ",
   "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg ",
   "debian-installer=en_US auto locale=en_US kbd-chooser/method=us ",
@@ -293,7 +293,7 @@ an Ubuntu 12.04 installer:
   "fb=false debconf/frontend=noninteractive ",
   "keyboard-configuration/modelcode=SKIP keyboard-configuration/layout=USA ",
   "keyboard-configuration/variant=USA console-setup/ask_detect=false ",
-  "initrd=/install/initrd.gz -- &lt;enter&gt;"
+  "initrd=/install/initrd.gz -- <enter>"
 ]
 ```
 


### PR DESCRIPTION
If copy and pasted, the boot command section was NOT working due to < and > being translated to HTML code equivalents. Removed javascript tagging on the code block to see if this fixes the resulting display in a browser.